### PR TITLE
Rename `staicoin` to `stai`

### DIFF
--- a/docs/proof-of-spacetime/foxy-pool/pools/stai-og/authenticate.md
+++ b/docs/proof-of-spacetime/foxy-pool/pools/stai-og/authenticate.md
@@ -7,36 +7,36 @@ From your [My Farmer](https://stai-og.foxypool.io/my-farmer){target=_blank} page
 
 Clicking it will open a modal with instructions on what to do next:
 
-1. Change into the directory, where the `staicoin` binary is located at. When using a git install this is inside the `./activate`-ed repo directory. Otherwise, please use the following:
+1. Change into the directory, where the `stai` binary is located at. When using a git install this is inside the `./activate`-ed repo directory. Otherwise, please use the following:
 
     === "Windows"
         Open a powershell window and enter the following command:
         ```PowerShell
-        cd (Get-Item "$ENV:LOCALAPPDATA\staicoin-blockchain\app*\resources\app.asar.unpacked\daemon").fullname
+        cd (Get-Item "$ENV:LOCALAPPDATA\stai-blockchain\app*\resources\app.asar.unpacked\daemon").fullname
         ```
 
     === "Mac OS"
         Open a terminal and enter the following command:
         ```zsh
-        cd /Applications/staicoin.app/Contents/Resources/app.asar.unpacked/daemon
+        cd /Applications/stai.app/Contents/Resources/app.asar.unpacked/daemon
         ```
 
     === "Linux"
         Open a terminal/bash and enter the following command:
         ```bash
-        cd /usr/lib/staicoin-blockchain/resources/app.asar.unpacked/daemon
+        cd /usr/lib/stai-blockchain/resources/app.asar.unpacked/daemon
         ```
 
 2. Next we need to obtain the fingerprint for the pool public key, by entering the following command into the shell:
 
     === "Windows"
         ```PowerShell
-        .\staicoin keys show
+        .\stai keys show
         ```
 
     === "Linux & Mac OS"
         ```bash
-        ./staicoin keys show
+        ./stai keys show
         ```
 
     !!! info
@@ -46,22 +46,22 @@ Clicking it will open a modal with instructions on what to do next:
 
     === "Windows"
         ```PowerShell
-        .\staicoin keys sign -t "m/12381/8444/1/0" -d <the data to sign here> -f <your fingerprint here>
+        .\stai keys sign -t "m/12381/8444/1/0" -d <the data to sign here> -f <your fingerprint here>
         ```
 
         ??? example
             ```PowerShell
-            .\staicoin keys sign -t "m/12381/8444/1/0" -d 1632306148 -f 67890123456
+            .\stai keys sign -t "m/12381/8444/1/0" -d 1632306148 -f 67890123456
             ```
 
     === "Linux & Mac OS"
         ```bash
-        ./staicoin keys sign -t "m/12381/8444/1/0" -d <the data to sign here> -f <your fingerprint here>
+        ./stai keys sign -t "m/12381/8444/1/0" -d <the data to sign here> -f <your fingerprint here>
         ```
 
         ??? example
             ```bash
-            ./staicoin keys sign -t "m/12381/8444/1/0" -d 1632306148 -f 67890123456
+            ./stai keys sign -t "m/12381/8444/1/0" -d 1632306148 -f 67890123456
             ```
 
     !!! info

--- a/docs/proof-of-spacetime/foxy-pool/pools/stai-og/faq.md
+++ b/docs/proof-of-spacetime/foxy-pool/pools/stai-og/faq.md
@@ -26,7 +26,7 @@
     Please ensure both `pool_url` and `pool_payout_address` are added into the farmer section and NOT full_node_peer section, it should be the same indentation as `full_node_peer`.
 
 ??? faq "I changed my config.yaml, but the config was reset?"
-    They are not gone, just re-arranged. The staicoin-blockchain software sorts the config keys alphabetically.
+    They are not gone, just re-arranged. The stai-blockchain software sorts the config keys alphabetically.
 
 ??? faq "I can't log in with my pool public key?"
     You can log in once you submitted your first partial to the pool. Check out the section on how to [verify your farmer is working correctly](getting-started.md#verify-your-farmer-is-working-correctly).

--- a/docs/proof-of-spacetime/foxy-pool/pools/stai-og/getting-started.md
+++ b/docs/proof-of-spacetime/foxy-pool/pools/stai-og/getting-started.md
@@ -13,19 +13,19 @@
 !!! info
     The following changes are only necessary for the node running the `farmer` service. If you run the GUI you also run the `farmer` service. As such if you run a multi harvester setup you only need to update the node with the farmer on it, the harvesters can remain as is.
 
-1. To get started farming on [Foxy-Pool STAI (OG)](https://stai-og.foxypool.io){target=_blank} please download and install the pooling enabled staicoin-blockchain software from [here](https://github.com/foxypool/staicoin-blockchain/releases/latest){target=_blank}. The source is available on the `main` branch in case you prefer or require to build from source.
+1. To get started farming on [Foxy-Pool STAI (OG)](https://stai-og.foxypool.io){target=_blank} please download and install the pooling enabled stai-blockchain software from [here](https://github.com/foxypool/staicoin-blockchain/releases/latest){target=_blank}. The source is available on the `main` branch in case you prefer or require to build from source.
 2. Find your stai `config.yaml`:
    
     === "Linux & Mac OS"
 
         ```bash
-        ~/.staicoin/mainnet/config/config.yaml
+        ~/.stai/mainnet/config/config.yaml
         ```
    
     === "Windows"
 
         ```ps
-        C:\Users\<user>\.staicoin\mainnet\config\config.yaml
+        C:\Users\<user>\.stai\mainnet\config\config.yaml
         ```
 
 3. Now update your stai `config.yaml` with the following changes:
@@ -36,11 +36,11 @@
 
     ![config example](../../../../assets/img/getting-started/foxy-pool-stai-og-config-example.png){: loading=lazy }
 
-4. Save the `config.yaml` and (re-)start the pooling enabled staicoin-blockchain.
+4. Save the `config.yaml` and (re-)start the pooling enabled stai-blockchain.
 
 ## Verify your farmer is working correctly
 
-To verify your farmer is working correctly, please set your log level to `INFO` in your stai `config.yaml` and restart your staicoin-blockchain software.
+To verify your farmer is working correctly, please set your log level to `INFO` in your stai `config.yaml` and restart your stai-blockchain software.
 If the connection to the pool worked you'll now see a log entry in your stai `debug.log`:
 ```
 Connected to OG pool Foxy-Pool STAI (OG)
@@ -60,7 +60,7 @@ to check for them.
 
 ## Logging in
 
-To see your farmers stats on the [My Farmer](https://stai-og.foxypool.io/my-farmer){target=_blank} tab of the pool you need to log in with the pool public key used by your plots. The pool public key can be found in your stai `config.yaml` in the `pool_public_keys` list or via `staicoin keys show`.
+To see your farmers stats on the [My Farmer](https://stai-og.foxypool.io/my-farmer){target=_blank} tab of the pool you need to log in with the pool public key used by your plots. The pool public key can be found in your stai `config.yaml` in the `pool_public_keys` list or via `stai keys show`.
 
 It is advisable to authenticate at this stage, so you can change your name, set a minimum payout amount or [leave the pool](#leaving-the-pool). To do so please follow the steps described in [Authenticate](authenticate.md)
 
@@ -73,7 +73,7 @@ To leave the pool (temporary or permanent) please follow these steps:
 
     ![leave pool](../../../../assets/img/getting-started/leave-chia-pool.png){: loading=lazy }
 
-3. Once you have left the pool via the button, shut down your staicoin-blockchain software and head over to your stai `config.yaml`.
+3. Once you have left the pool via the button, shut down your stai-blockchain software and head over to your stai `config.yaml`.
 4. In the config remove the `pool_payout_address` and `pool_url` config options you added to the farmer section.
 5. **Important**: Change the `stai_target_address` in the pool config section back to one of your addresses so that block rewards are credited to you instead of the pool!
-6. Install the official staicoin-blockchain software.
+6. Install the official stai-blockchain software.


### PR DESCRIPTION
renames the staicoin to stai but left staicoin in the link to the github as its still called staicoin